### PR TITLE
Fix updating items in nested templates

### DIFF
--- a/ios/Classes/FCPProtocols.swift
+++ b/ios/Classes/FCPProtocols.swift
@@ -5,6 +5,12 @@
 //  Created by Oğuzhan Atalay on 25.08.2021.
 //
 
+import CarPlay
+
 protocol FCPPresentTemplate {}
 
-protocol FCPRootTemplate { }
+protocol FCPRootTemplate {
+  associatedtype TemplateType: CPTemplate
+
+  var get: TemplateType { get }
+}

--- a/lib/controllers/carplay_controller.dart
+++ b/lib/controllers/carplay_controller.dart
@@ -40,36 +40,28 @@ class FlutterCarPlayController {
         <String, dynamic>{...updatedListItem.toJson()}).then((value) {
       if (value) {
         l1:
-        for (var h in templateHistory) {
-          switch (h.runtimeType) {
-            case CPTabBarTemplate:
-              for (var t in (h as CPTabBarTemplate).templates) {
-                for (var s in t.sections) {
-                  for (var i in s.items) {
-                    if (i.uniqueId == updatedListItem.uniqueId) {
-                      currentRootTemplate!
-                          .templates[currentRootTemplate!.templates.indexOf(t)]
-                          .sections[t.sections.indexOf(s)]
-                          .items[s.items.indexOf(i)] = updatedListItem;
-                      break l1;
-                    }
-                  }
-                }
-              }
-              break;
-            case CPListTemplate:
-              for (var s in (h as CPListTemplate).sections) {
-                for (var i in s.items) {
-                  if (i.uniqueId == updatedListItem.uniqueId) {
-                    currentRootTemplate!
-                        .sections[currentRootTemplate!.sections.indexOf(s)]
-                        .items[s.items.indexOf(i)] = updatedListItem;
+        for (var template in templateHistory) {
+          if (template is CPTabBarTemplate) {
+            for (var template in template.templates) {
+              for (var section in template.sections) {
+                for (var item in section.items) {
+                  if (item.uniqueId == updatedListItem.uniqueId) {
+                    section.items[section.items.indexOf(item)] =
+                        updatedListItem;
                     break l1;
                   }
                 }
               }
-              break;
-            default:
+            }
+          } else if (template is CPListTemplate) {
+            for (var section in template.sections) {
+              for (var item in section.items) {
+                if (item.uniqueId == updatedListItem.uniqueId) {
+                  section.items[section.items.indexOf(item)] = updatedListItem;
+                  break l1;
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
Before, `findItem()` would only search for items in the root template. That meant that items in other, pushed templates couldn't be updated. We now search in every template in the current stack